### PR TITLE
Validate branch names when push destination list includes a Pantheon repository

### DIFF
--- a/.github/workflows/code_standards.yml
+++ b/.github/workflows/code_standards.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [0.x]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+  pull_request:
+    branches: [0.x]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+
+jobs:
+    code_guidelines:
+      name: Code Guidelines
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          php_version: [8.1, 8.2, 8.3]
+      steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@2.32.0
+        with:
+          php-version: ${{ matrix.php_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction
+
+      - name: Run PHP_CodeSniffer
+        run: composer cs
+
+      - name: Lint
+        run: composer lint
+
+      - name: Run PHPStan
+        run: composer sa

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "allow-plugins": {
             "digitalpolygon/polymer": true,
             "digitalpolygon/drupal-upgrade-plugin": true,
+            "phpstan/extension-installer": true,
             "phpro/grumphp-shim": true
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,28 @@
     "require": {
         "digitalpolygon/polymer-drupal": "0.x-dev"
     },
+    "require-dev": {
+        "php-parallel-lint/php-parallel-lint": "^1.4",
+        "phpro/grumphp-shim": "^2.5",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^1.11",
+        "squizlabs/php_codesniffer": "^3"
+    },
     "config": {
         "allow-plugins": {
             "digitalpolygon/polymer": true,
             "digitalpolygon/drupal-upgrade-plugin": true,
             "phpro/grumphp-shim": true
         }
+    },
+    "scripts": {
+        "lint": "find src test/src -name '*.php' -print0 | xargs -0 -n1 -P4 -- php -l",
+        "cs": "phpcs",
+        "sa": "phpstan analyse -v -c phpstan.neon",
+        "validations": [
+            "@lint",
+            "@cs",
+            "@sa"
+        ]
     }
 }

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,2 @@
+pantheon:
+  git-repo-regex: '/^ssh:\/\/codeserver\.dev\.[a-f0-9\-]+@codeserver\.dev\.[a-f0-9\-]+\.drush\.in:2222\/~\/repository\.git$/'

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="polymer">
-    <description>Default PHP CodeSniffer configuration for Polymer project.</description>
+    <description>Default PHP CodeSniffer configuration for Polymer projects and extensions.</description>
     <file>src</file>
-    <exclude-pattern type="relative">/var/www/html/test_drupal10/*\.php</exclude-pattern>
-    <file>bin</file>
     <rule ref="PSR12"/>
 
     <!--    Keep us sane-->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="polymer">
+    <description>Default PHP CodeSniffer configuration for Polymer project.</description>
+    <file>src</file>
+    <exclude-pattern type="relative">/var/www/html/test_drupal10/*\.php</exclude-pattern>
+    <file>bin</file>
+    <rule ref="PSR12"/>
+
+    <!--    Keep us sane-->
+<!--    <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed"><severity>0</severity></rule>-->
+<!--    <rule ref="PSR2.Methods.MethodDeclaration.Underscore"><severity>0</severity></rule>-->
+<!--    <rule ref="PSR12.Files.FileHeader.IncorrectOrder"><severity>0</severity></rule>-->
+
+    <arg value="n" />
+    <arg value="s" />
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 6
+    paths:
+        - src

--- a/src/Polymer/Plugin/Commands/WorkflowCommands.php
+++ b/src/Polymer/Plugin/Commands/WorkflowCommands.php
@@ -2,7 +2,7 @@
 
 namespace DigitalPolygon\PolymerPantheon\Drupal\Polymer\Plugin\Commands;
 
-use Composer\IO\ConsoleIO;
+use Robo\Symfony\ConsoleIO;
 use Consolidation\AnnotatedCommand\Attributes\Command;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 
@@ -10,8 +10,6 @@ class WorkflowCommands extends TaskBase
 {
   /**
    * Generate Pantheon GitHub workflow.
-   *
-   * @param \Composer\IO\ConsoleIO $io
    *
    * @return int
    */

--- a/src/Polymer/Plugin/Commands/WorkflowCommands.php
+++ b/src/Polymer/Plugin/Commands/WorkflowCommands.php
@@ -6,8 +6,8 @@ use Composer\IO\ConsoleIO;
 use Consolidation\AnnotatedCommand\Attributes\Command;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 
-class WorkflowCommands extends TaskBase {
-
+class WorkflowCommands extends TaskBase
+{
   /**
    * Generate Pantheon GitHub workflow.
    *
@@ -15,9 +15,10 @@ class WorkflowCommands extends TaskBase {
    *
    * @return int
    */
-  #[Command(name: 'pantheon:workflows:generate:drupal')]
-  public function testCommand(ConsoleIO $io): int {
-    $io->write("Test workflows command.");
-    return 0;
-  }
+    #[Command(name: 'pantheon:workflows:generate:drupal')]
+    public function testCommand(ConsoleIO $io): int
+    {
+        $io->write("Test workflows command.");
+        return 0;
+    }
 }

--- a/src/Polymer/Plugin/Hooks/PantheonArtifactHook.php
+++ b/src/Polymer/Plugin/Hooks/PantheonArtifactHook.php
@@ -11,20 +11,21 @@ use DigitalPolygon\Polymer\Robo\Commands\Artifact\DeployCommand;
 use DigitalPolygon\Polymer\Robo\Exceptions\BadConfigurationValueException;
 use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
 
-class PantheonArtifactHook extends TaskBase {
+class PantheonArtifactHook extends TaskBase
+{
+    protected const PANTHEON_GIT_URL_REGEX = '/^ssh:\/\/codeserver\.dev\.[a-f0-9\-]+@codeserver\.dev\.[a-f0-9\-]+\.drush\.in:2222\/~\/repository\.git$/';
+    protected const MULTIDEV_NAME_REGEX = '/^(?!.*-.*-)[a-z\-]{1,11}$/';
 
-  protected const PANTHEON_GIT_URL_REGEX = '/^ssh:\/\/codeserver\.dev\.[a-f0-9\-]+@codeserver\.dev\.[a-f0-9\-]+\.drush\.in:2222\/~\/repository\.git$/';
-  protected const MULTIDEV_NAME_REGEX = '/^(?!.*-.*-)[a-z\-]{1,11}$/';
-
-  #[Hook(type: HookManager::OPTION_HOOK, target: DeployCommand::ARTIFACT_DEPLOY_COMMAND)]
-  public function addPantheonOptions(AnnotatedCommand $command, AnnotationData $annotationData): void {
-//    $command->addOption(
-//      '--multidev-update',
-//      'u',
-//      InputOption::VALUE_NONE,
-//      'Create or update related multidev environment after successful deployment.',
-//    );
-  }
+    #[Hook(type: HookManager::OPTION_HOOK, target: DeployCommand::ARTIFACT_DEPLOY_COMMAND)]
+    public function addPantheonOptions(AnnotatedCommand $command, AnnotationData $annotationData): void
+    {
+  //    $command->addOption(
+  //      '--multidev-update',
+  //      'u',
+  //      InputOption::VALUE_NONE,
+  //      'Create or update related multidev environment after successful deployment.',
+  //    );
+    }
 
   /**
    * @param \Consolidation\AnnotatedCommand\CommandData $commandData
@@ -32,35 +33,37 @@ class PantheonArtifactHook extends TaskBase {
    * @return void
    * @throws \Exception
    */
-  #[Hook(type: HookManager::ARGUMENT_VALIDATOR, target: DeployCommand::ARTIFACT_DEPLOY_COMMAND)]
-  public function validate(CommandData $commandData): void {
-    $pantheonRemotes = $this->getPantheonRemotes();
-    if (!empty($pantheonRemotes)) {
-      // Since a Pantheon repository is in the list of repositories to push to
-      // we need to make sure that branch naming standards are met.
-      $branchName = $commandData->input()->getOption('branch');
-      if (is_string($branchName)) {
-        $this->branchNameIsValid($branchName);
-      }
-      if (is_string($commandData->input()->getOption('tag'))) {
-        throw new \Exception('Tagging is not supported for Pantheon repositories.');
-      }
+    #[Hook(type: HookManager::ARGUMENT_VALIDATOR, target: DeployCommand::ARTIFACT_DEPLOY_COMMAND)]
+    public function validate(CommandData $commandData): void
+    {
+        $pantheonRemotes = $this->getPantheonRemotes();
+        if (!empty($pantheonRemotes)) {
+          // Since a Pantheon repository is in the list of repositories to push to
+          // we need to make sure that branch naming standards are met.
+            $branchName = $commandData->input()->getOption('branch');
+            if (is_string($branchName)) {
+                $this->branchNameIsValid($branchName);
+            }
+            if (is_string($commandData->input()->getOption('tag'))) {
+                throw new \Exception('Tagging is not supported for Pantheon repositories.');
+            }
+        }
     }
-  }
 
   /**
    * @return string[]
    */
-  protected function getPantheonRemotes(): array {
-    $configuredRemotes = $this->getConfigValue('git.remotes');
-    $pantheonRemotes = [];
-    foreach ($configuredRemotes as $remote) {
-      if (preg_match($this->getPantheonRepoRegex(), $remote)) {
-        $pantheonRemotes[] = $remote;
-      }
+    protected function getPantheonRemotes(): array
+    {
+        $configuredRemotes = $this->getConfigValue('git.remotes');
+        $pantheonRemotes = [];
+        foreach ($configuredRemotes as $remote) {
+            if (preg_match($this->getPantheonRepoRegex(), $remote)) {
+                $pantheonRemotes[] = $remote;
+            }
+        }
+        return $pantheonRemotes;
     }
-    return $pantheonRemotes;
-  }
 
   /**
    * @param string $branchName
@@ -68,55 +71,56 @@ class PantheonArtifactHook extends TaskBase {
    * @return void
    * @throws \Exception
    */
-  protected function branchNameIsValid(string $branchName): void {
-    // From https://docs.pantheon.io/guides/multidev/create-multidev
-    // Multidev branch names must be all lowercase, no more than 11 characters,
-    // and can contain a dash (-).
-    // Environments cannot be created with the following reserved names:
+    protected function branchNameIsValid(string $branchName): void
+    {
+      // From https://docs.pantheon.io/guides/multidev/create-multidev
+      // Multidev branch names must be all lowercase, no more than 11 characters,
+      // and can contain a dash (-).
+      // Environments cannot be created with the following reserved names:
 
-    // Check if branch is master and allow it.
-    if ('master' === $branchName) {
-      // Always allow pushes to Pantheon master.
-      return;
-    }
-
-    // Assume all other branches are meant for multidev environments. Validate
-    // against Pantheon's multidev environment naming requirements.
-    if (!preg_match(self::MULTIDEV_NAME_REGEX, $branchName)) {
-      throw new \Exception("Branch name '$branchName' is invalid. Pantheon multidev branch names must be all lowercase, no more than 11 characters, and can contain a dash (-).");
-    }
-
-    // The following names are reserved by Pantheon and cannot be used as
-    // multidev environment names.
-    $bannedMultidevNames = [
-      'settings',
-      'team',
-      'support',
-      'multidev',
-      'debug',
-      'files',
-      'tags',
-      'billing',
-    ];
-    if (in_array($branchName, $bannedMultidevNames, TRUE)) {
-      throw new \Exception("Branch name '$branchName' is invalid. Pantheon multidev branch names cannot be any of the following: " . implode(', ', $bannedMultidevNames));
-    }
-  }
-
-  protected function getPantheonRepoRegex(): string {
-    $configuredRegex = $this->getConfigValue('pantheon.git-repo-regex');
-    try {
-      if (is_string($configuredRegex)) {
-        if (@preg_match($configuredRegex, 'asdfadf') === false) {
-          throw new BadConfigurationValueException('pantheon.git-repo-regex', $configuredRegex, self::PANTHEON_GIT_URL_REGEX);
+      // Check if branch is master and allow it.
+        if ('master' === $branchName) {
+          // Always allow pushes to Pantheon master.
+            return;
         }
-      }
-    } catch (BadConfigurationValueException $e) {
-      if ($this->logger) {
-        $this->logger->warning($e->getMessage());
-      }
-    }
-    return self::PANTHEON_GIT_URL_REGEX;
-  }
 
+      // Assume all other branches are meant for multidev environments. Validate
+      // against Pantheon's multidev environment naming requirements.
+        if (!preg_match(self::MULTIDEV_NAME_REGEX, $branchName)) {
+            throw new \Exception("Branch name '$branchName' is invalid. Pantheon multidev branch names must be all lowercase, no more than 11 characters, and can contain a dash (-).");
+        }
+
+      // The following names are reserved by Pantheon and cannot be used as
+      // multidev environment names.
+        $bannedMultidevNames = [
+        'settings',
+        'team',
+        'support',
+        'multidev',
+        'debug',
+        'files',
+        'tags',
+        'billing',
+        ];
+        if (in_array($branchName, $bannedMultidevNames, true)) {
+            throw new \Exception("Branch name '$branchName' is invalid. Pantheon multidev branch names cannot be any of the following: " . implode(', ', $bannedMultidevNames));
+        }
+    }
+
+    protected function getPantheonRepoRegex(): string
+    {
+        $configuredRegex = $this->getConfigValue('pantheon.git-repo-regex');
+        try {
+            if (is_string($configuredRegex)) {
+                if (@preg_match($configuredRegex, 'asdfadf') === false) {
+                    throw new BadConfigurationValueException('pantheon.git-repo-regex', $configuredRegex, self::PANTHEON_GIT_URL_REGEX);
+                }
+            }
+        } catch (BadConfigurationValueException $e) {
+            if ($this->logger) {
+                $this->logger->warning($e->getMessage());
+            }
+        }
+        return self::PANTHEON_GIT_URL_REGEX;
+    }
 }

--- a/src/Polymer/Plugin/Hooks/PantheonArtifactHook.php
+++ b/src/Polymer/Plugin/Hooks/PantheonArtifactHook.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace DigitalPolygon\PolymerPantheon\Drupal\Polymer\Plugin\Hooks;
+
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Attributes\Hook;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use DigitalPolygon\Polymer\Robo\Commands\Artifact\DeployCommand;
+use DigitalPolygon\Polymer\Robo\Exceptions\BadConfigurationValueException;
+use DigitalPolygon\Polymer\Robo\Tasks\TaskBase;
+
+class PantheonArtifactHook extends TaskBase {
+
+  protected const PANTHEON_GIT_URL_REGEX = '/^ssh:\/\/codeserver\.dev\.[a-f0-9\-]+@codeserver\.dev\.[a-f0-9\-]+\.drush\.in:2222\/~\/repository\.git$/';
+  protected const MULTIDEV_NAME_REGEX = '/^(?!.*-.*-)[a-z\-]{1,11}$/';
+
+  #[Hook(type: HookManager::OPTION_HOOK, target: DeployCommand::ARTIFACT_DEPLOY_COMMAND)]
+  public function addPantheonOptions(AnnotatedCommand $command, AnnotationData $annotationData): void {
+//    $command->addOption(
+//      '--multidev-update',
+//      'u',
+//      InputOption::VALUE_NONE,
+//      'Create or update related multidev environment after successful deployment.',
+//    );
+  }
+
+  /**
+   * @param \Consolidation\AnnotatedCommand\CommandData $commandData
+   *
+   * @return void
+   * @throws \Exception
+   */
+  #[Hook(type: HookManager::ARGUMENT_VALIDATOR, target: DeployCommand::ARTIFACT_DEPLOY_COMMAND)]
+  public function validate(CommandData $commandData): void {
+    $pantheonRemotes = $this->getPantheonRemotes();
+    if (!empty($pantheonRemotes)) {
+      // Since a Pantheon repository is in the list of repositories to push to
+      // we need to make sure that branch naming standards are met.
+      $branchName = $commandData->input()->getOption('branch');
+      if (is_string($branchName)) {
+        $this->branchNameIsValid($branchName);
+      }
+      if (is_string($commandData->input()->getOption('tag'))) {
+        throw new \Exception('Tagging is not supported for Pantheon repositories.');
+      }
+    }
+  }
+
+  /**
+   * @return string[]
+   */
+  protected function getPantheonRemotes(): array {
+    $configuredRemotes = $this->getConfigValue('git.remotes');
+    $pantheonRemotes = [];
+    foreach ($configuredRemotes as $remote) {
+      if (preg_match($this->getPantheonRepoRegex(), $remote)) {
+        $pantheonRemotes[] = $remote;
+      }
+    }
+    return $pantheonRemotes;
+  }
+
+  /**
+   * @param string $branchName
+   *
+   * @return void
+   * @throws \Exception
+   */
+  protected function branchNameIsValid(string $branchName): void {
+    // From https://docs.pantheon.io/guides/multidev/create-multidev
+    // Multidev branch names must be all lowercase, no more than 11 characters,
+    // and can contain a dash (-).
+    // Environments cannot be created with the following reserved names:
+
+    // Check if branch is master and allow it.
+    if ('master' === $branchName) {
+      // Always allow pushes to Pantheon master.
+      return;
+    }
+
+    // Assume all other branches are meant for multidev environments. Validate
+    // against Pantheon's multidev environment naming requirements.
+    if (!preg_match(self::MULTIDEV_NAME_REGEX, $branchName)) {
+      throw new \Exception("Branch name '$branchName' is invalid. Pantheon multidev branch names must be all lowercase, no more than 11 characters, and can contain a dash (-).");
+    }
+
+    // The following names are reserved by Pantheon and cannot be used as
+    // multidev environment names.
+    $bannedMultidevNames = [
+      'settings',
+      'team',
+      'support',
+      'multidev',
+      'debug',
+      'files',
+      'tags',
+      'billing',
+    ];
+    if (in_array($branchName, $bannedMultidevNames, TRUE)) {
+      throw new \Exception("Branch name '$branchName' is invalid. Pantheon multidev branch names cannot be any of the following: " . implode(', ', $bannedMultidevNames));
+    }
+  }
+
+  protected function getPantheonRepoRegex(): string {
+    $configuredRegex = $this->getConfigValue('pantheon.git-repo-regex');
+    try {
+      if (is_string($configuredRegex)) {
+        if (@preg_match($configuredRegex, 'asdfadf') === false) {
+          throw new BadConfigurationValueException('pantheon.git-repo-regex', $configuredRegex, self::PANTHEON_GIT_URL_REGEX);
+        }
+      }
+    } catch (BadConfigurationValueException $e) {
+      if ($this->logger) {
+        $this->logger->warning($e->getMessage());
+      }
+    }
+    return self::PANTHEON_GIT_URL_REGEX;
+  }
+
+}


### PR DESCRIPTION
# Changes

- When deploying an artifact, validate branch names against Pantheon's branch rules (https://docs.pantheon.io/guides/multidev/create-multidev)
    - Tags are disallowed on Pantheon.

## Chores

- Add PHPCS and PHPStan support.

Fixes #2.