### PR TITLE
Issue 4: Add drush site yaml creation.

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,11 @@
 pantheon:
   git-repo-regex: '/^ssh:\/\/codeserver\.dev\.[a-f0-9\-]+@codeserver\.dev\.[a-f0-9\-]+\.drush\.in:2222\/~\/repository\.git$/'
+  site-info:
+    id: ~
+    name: ~
+  terminus:
+    machine-token: ~
+    command: terminus
   workflow:
     files:
       github:

--- a/pantheon_files/drush.site.yml
+++ b/pantheon_files/drush.site.yml
@@ -1,0 +1,11 @@
+'*':
+  host: appserver.${env-name}.#site-id#.drush.in
+  paths:
+    files: files
+    private: files/private
+  uri: ${env-name}-#site-name#.pantheonsite.io
+  user: ${env-name}.#site-id#
+  ssh:
+    options: '-p 2222 -o "AddressFamily inet"'
+    tty: false
+


### PR DESCRIPTION
# Changes

- Add `pantheon:files:generate-drush-site-yaml` which will generate a Drush site file so long as `pantheon.site-info.id` and `pantheon.site-info.name` are set.

Fixes #4.